### PR TITLE
Update STWT_PHISHTANK url to use https.

### DIFF
--- a/lists/remote.toml
+++ b/lists/remote.toml
@@ -11,7 +11,7 @@ limits.entry-size = 512
 
 [http-lookup.STWT_PHISHTANK]
 enable = true
-url = "http://data.phishtank.com/data/online-valid.csv.gz"
+url = "https://data.phishtank.com/data/online-valid.csv.gz"
 format = "csv"
 separator = ","
 index.key = 1


### PR DESCRIPTION
The url seems to work fine over https, maybe that wasn't the case when the file was created or it's a typo?