### PR TITLE
Download geo ipv4 and ipv6 csv files

### DIFF
--- a/rules/asn.toml
+++ b/rules/asn.toml
@@ -8,4 +8,4 @@ max-size = 104857600
 asn = [ "https://cdn.jsdelivr.net/npm/@ip-location-db/asn/asn-ipv4.csv", 
         "https://cdn.jsdelivr.net/npm/@ip-location-db/asn/asn-ipv6.csv" ]
 geo = [ "https://cdn.jsdelivr.net/npm/@ip-location-db/geolite2-geo-whois-asn-country/geolite2-geo-whois-asn-country-ipv4.csv", 
-        "https://cdn.jsdelivr.net/npm/@ip-location-db/geolite2-geo-whois-asn-country/geolite2-geo-whois-asn-country-ipv4.csv" ]
+        "https://cdn.jsdelivr.net/npm/@ip-location-db/geolite2-geo-whois-asn-country/geolite2-geo-whois-asn-country-ipv6.csv" ]


### PR DESCRIPTION
The existing rules were downloading the IPv4 geo file twice (`geolite2-geo-whois-asn-country-ipv4.csv`).
This updates the list to download both the IPv4 (`geolite2-geo-whois-asn-country-ipv4.csv`) and the IPv6 (`geolite2-geo-whois-asn-country-ipv6.csv`) files.