### PR TITLE
Update `MW_SURBL_MULTI` compare to match docs

### DIFF
--- a/rules/dnsbl.toml
+++ b/rules/dnsbl.toml
@@ -150,7 +150,7 @@ zone = "value + '.multi.surbl.org'"
 tag = [ { if = "octets[3] == 128", then = "'CRACKED_SURBL'" },
         { if = "octets[3] == 64", then = "'ABUSE_SURBL'" },
         { if = "octets[3] == 32", then = "'CT_SURBL'" },
-        { if = "octets[3] == 18", then = "'MW_SURBL_MULTI'" },
+        { if = "octets[3] == 16", then = "'MW_SURBL_MULTI'" },
         { if = "octets[3] == 8", then = "'PH_SURBL_MULTI'" },
         { if = "octets[3] == 4", then = "'DM_SURBL'" },
         { if = "octets[3] == 1", then = "'SURBL_BLOCKED'" },


### PR DESCRIPTION
Per the [SURBL Lists documentation](https://www.surbl.org/lists), `multi.surbl.org` returns a bitmasked result where each list is represented by one bit (and hence a power of two).

`spam-filter.dnsbl.server.STWT_SURBL_DOMAIN` contained a typo that was comparing the octet against `18` instead of `16` for `MW_SURBL_MULTI`.

This updates the comparison to `16` to match the documentation for `multi.surbl.org`.